### PR TITLE
added ender chests, named items

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PHP 5.3+ with the gmp extension.
 
 Supports:
 ---------
-Inventory, Armor
+Inventory, EnderChest contents, Armor
 
 Currently missing:
 ------------------

--- a/class.ItemStack.php
+++ b/class.ItemStack.php
@@ -29,4 +29,11 @@ class ItemStack
 		}
 		$this->meta["enchants"][$type] = $level;
 	}
+
+	public function display($display)
+	{
+		$this->meta["=="] = "ItemMeta";
+		$this->meta["meta-type"] = "UNSPECIFIC";
+		$this->meta["display-name"] = $display->name;
+	}
 }

--- a/class.MVInv.php
+++ b/class.MVInv.php
@@ -49,7 +49,7 @@ class MVInv
 		}
 	}
 
-	public function load($inventory)
+	public function loadInv($inventory)
 	{
 		print "MVInv: loading ".count($inventory)." items...\n";
 		foreach($inventory as $item) {
@@ -59,11 +59,33 @@ class MVInv
 					$itemstack->enchant($ench->id,$ench->level);
 				}
 			}
+			if(!is_null($item->tag) && !is_null($item->tag->display)) {
+				$itemstack->display($item->tag->display);
+			}
 			if($item->slot < 100) {
 				$this->addItem($itemstack,$item->slot);
 			} else {
 				$this->addArmor($itemstack,($item->slot-100));
 			}
+		}
+	}
+
+	public function loadEnderInv($inventory)
+	{
+		print "MVInv: loading ".count($inventory)." items...\n";
+		foreach($inventory as $item) {
+			$itemstack = new ItemStack($item->id,$item->count,$item->damage);
+			if(!is_null($item->tag) && !is_null($item->tag->enchantments)) {
+				foreach($item->tag->enchantments as $ench) {
+					$itemstack->enchant($ench->id,$ench->level);
+				}
+			}
+			if(!is_null($item->tag) && !is_null($item->tag->display)) {
+				$itemstack->display($item->tag->display);
+			}
+			if($item->slot < 100) {
+				$this->addEnderChest($itemstack,$item->slot);
+			} 
 		}
 	}
 

--- a/class.NBTInv.php
+++ b/class.NBTInv.php
@@ -8,7 +8,7 @@ class NBTInv extends nbt
 	 * gets player inventory from nbt file
 	 * optionally provide raw nbt data using format=false
 	 */
-	public function get($format=true)
+	public function getInv($format=true)
 	{
 		foreach($this->root[0]["value"] as $node) {
 			$node = (object)$node;
@@ -17,6 +17,21 @@ class NBTInv extends nbt
 			}
 		}
 		if($format === true) {
+			return $this->formatAll($inventory->value);
+		} else {
+			return $inventory;
+		}
+	}
+
+	public function getEnderInv($format=true)
+	{
+		foreach($this->root[0]["value"] as $node) {
+			$node = (object)$node;
+			if($node->name == "EnderItems") {
+				$inventory = (object)$node->value;
+			}
+		}
+		if($format === true && !is_null($inventory)) {
 			return $this->formatAll($inventory->value);
 		} else {
 			return $inventory;
@@ -55,7 +70,7 @@ class NBTInv extends nbt
 				$ret->count = $att->value;
 				break;
 			case "tag":
-				$ret->tag = $this->formatTags($att->value);
+				$ret->tag = $this->formatTag($att->value);
 				break;
 			case "slot":
 				$ret->slot = $att->value;
@@ -70,10 +85,10 @@ class NBTInv extends nbt
 	/**
 	 * given an array of tags, formats them
 	 */
-	private function formatTags($tags)
+	private function formatTag($tag_entries)
 	{
 		$ret = new StdClass();
-		foreach($tags as $att) {
+		foreach($tag_entries as $att) {
 			$att = (object)$att;
 			switch(strtolower($att->name)) 
 			{
@@ -85,6 +100,12 @@ class NBTInv extends nbt
 					$ret->enchantments[] = $this->formatEnchantment($enchantment);
 				}
 				break;
+			case "display":
+				$ret->display = $this->formatDisplay($att->value);
+				break;
+			case "fireworks":
+				$ret->firework = $this->formatFirework($att->value);
+				break;
 			default:
 				throw new Exception("unrecognized tag name `{$att->name}`. dump: ".json_encode($att));
 			}
@@ -95,10 +116,10 @@ class NBTInv extends nbt
 	/**
 	 * given enchantment data, formats it
 	 */
-	private function formatEnchantment($enchantment)
+	private function formatEnchantment($enchantment_entries)
 	{
 		$ret = new StdClass();
-		foreach($enchantment as $att)
+		foreach($enchantment_entries as $att)
 		{
 			$att = (object)$att;
 			switch(strtolower($att->name))
@@ -108,6 +129,91 @@ class NBTInv extends nbt
 				break;
 			case "lvl":
 				$ret->level = $att->value;
+				break;
+			default:
+				throw new Exception("unrecognized enchantment attribute `{$att->name}`. dump: ".json_encode($enchantment));
+			}
+		}
+		return $ret;
+	}
+
+	/**
+	 * given display data, formats it
+	 */
+	private function formatDisplay($display_entries)
+	{
+		$ret = new StdClass();
+		foreach($display_entries as $att) {
+			$att = (object)$att;
+			switch(strtolower($att->name)) 
+			{
+			case "name":
+				$ret->name = $att->value;
+				break;
+			case "color":
+				$ret->color = $att->value;
+				break;
+			case "lore":
+				// nothing yet
+				break;
+			default:
+				throw new Exception("unrecognized display attribute `{$att->name}`. dump: ".json_encode($display));
+			}
+		}
+		return $ret;
+	}
+
+
+	/**
+	 * given fireworks data, formats it
+	 */
+	private function formatFirework($firework_entries)
+	{
+		$ret = new StdClass();
+		foreach($firework_entries as $att) {
+			$att = (object)$att;
+			switch(strtolower($att->name)) 
+			{
+			case "flight":
+				$ret->flight = $att->value;
+				break;
+			case "explosions":
+				foreach($att->value['value'] as $explosion) {
+					$ret->explosions[] = $this->formatexplosion($explosion);
+				}
+				break;
+			default:
+				throw new Exception("unrecognized display attribute `{$att->name}`. dump: ".json_encode($display));
+			}
+		}
+		return $ret;
+	}
+
+	/**
+	 * given explosion data, formats it
+	 */
+	private function formatExplosion($explosion_entries)
+	{
+		$ret = new StdClass();
+		foreach($explosion_entries as $att)
+		{
+			$att = (object)$att;
+			switch(strtolower($att->name))
+			{
+			case "flicker":
+				$ret->flicker = $att->value;
+				break;
+			case "type":
+				$ret->type = $att->value;
+				break;
+			case "trails":
+				$ret->trails = $att->value;
+				break;
+			case "colors":
+				$ret->colors = $att->value;
+				break;
+			case "fadecolors":
+				$ret->fade_colors = $att->value;
 				break;
 			default:
 				throw new Exception("unrecognized enchantment attribute `{$att->name}`. dump: ".json_encode($enchantment));

--- a/convert.php
+++ b/convert.php
@@ -20,9 +20,11 @@ if(empty($nbt_file)) {
 /* load and parse the nbt inventory data */
 $nbtinv = new NBTInv();
 $nbtinv->loadFile($nbt_file);
-$inventory = $nbtinv->get();
+$inventory = $nbtinv->getInv();
+$ender_inventory = $nbtinv->getEnderInv();
 
 /* init Multiverse Inventory from the data above */
 $mvinv = new MVInv();
-$mvinv->load($inventory);
+$mvinv->loadInv($inventory);
+$mvinv->loadEnderInv($ender_inventory);
 $mvinv->writeJSON($json_file);

--- a/nbt.class.php
+++ b/nbt.class.php
@@ -31,6 +31,7 @@ class NBT {
 	const TAG_STRING = 8;
 	const TAG_LIST = 9;
 	const TAG_COMPOUND = 10;
+	const TAG_INT_ARRAY = 11;
 	
 	public function loadFile($filename, $wrapper = "compress.zlib://") {
 		if(is_string($wrapper) && is_file($filename)) {
@@ -148,6 +149,11 @@ class NBT {
 				$tree = array();
 				while($this->traverseTag($fp, $tree));
 				return $tree;
+			case self::TAG_INT_ARRAY: // int array
+				$arrayLength = $this->readType($fp, self::TAG_INT);
+				$array = array();
+				for($i = 0; $i < $arrayLength; $i++) $array[] = $this->readType($fp, self::TAG_INT);
+				return $array;
 		}
 	}
 	
@@ -187,6 +193,8 @@ class NBT {
 				foreach($value as $listItem) if(!$this->writeTag($fp, $listItem)) return false;
 				if(!is_int(fwrite($fp, "\0"))) return false;
 				return true;
+			case self::TAG_INT_ARRAY: // Int array
+				return $this->writeType($fp, self::TAG_INT, count($value)) && is_int(fwrite($fp, call_user_func_array("pack", array_merge(array("N".count($value)), $value))));
 		}
 	}
 }


### PR DESCRIPTION
Ender Chest inventory is carried over now, as are item names.  Also the converter will no longer crash in the presence of leather armor colors, item lore, ore fireworks (necessitated updating nbt library to handle TAG_INT_ARRAY).  Colors are parsed, and fireworks partially so, but are not yet saved to json
